### PR TITLE
Next

### DIFF
--- a/.husky/csx/foo.csx
+++ b/.husky/csx/foo.csx
@@ -1,0 +1,1 @@
+Console.WriteLine("Hello world from foo");

--- a/.husky/csx/hello.csx
+++ b/.husky/csx/hello.csx
@@ -1,6 +1,16 @@
+// example of using a nuget package
+// #r "nuget:Gridify, 2.5.0"
 
-Console.WriteLine("Hello World!");
+// example of using other csx files
+#load "foo.csx"
 
 var message = "Husky supports csharp scripting!";
 
+Console.ForegroundColor = ConsoleColor.Green;
 Console.WriteLine(message);
+
+foreach (var arg in Args)
+{
+    Console.WriteLine($"arg: {arg}");
+}
+

--- a/src/Husky/Cli.cs
+++ b/src/Husky/Cli.cs
@@ -64,7 +64,8 @@ public static class Cli
          "add" when ac >= 3 => await CliActions.Add(args[1], args[2]),
          "run" when ac is 1 => await CliActions.Run(),
          "run" => await CliActions.Run(args.Skip(1).ToArray()),
-         "exec" when ac >= 2 => await CliActions.Exec(args[1]),
+         "exec" when ac == 2 => await CliActions.Exec(args[1], Array.Empty<string>()),
+         "exec" when ac > 2 => await CliActions.Exec(args[1], args.Skip(2).ToArray()),
          _ => InvalidCommand()
       };
    }

--- a/src/Husky/Cli.cs
+++ b/src/Husky/Cli.cs
@@ -60,6 +60,8 @@ public static class Cli
          "install" when ac > 1 && !args[1].StartsWith("-") => await CliActions.Install(args[1]),
          "install" => await CliActions.Install(),
          "uninstall" => await CliActions.Uninstall(),
+         "set" when ac == 2 => await CliActions.Set(args[1], "dotnet husky run"),
+         "add" when ac == 2 => await CliActions.Add(args[1], "dotnet husky run"),
          "set" when ac >= 3 => await CliActions.Set(args[1], args[2]),
          "add" when ac >= 3 => await CliActions.Add(args[1], args[2]),
          "run" when ac is 1 => await CliActions.Run(),
@@ -90,7 +92,7 @@ Commands:
    husky install [dir] (default: .husky)   Install Husky hooks
    husky uninstall                         Uninstall Husky hooks
    husky set <.husky/file> [cmd]           Set Husky hook (.husky/pre-push ""dotnet test"")
-   husky add <.husky/file> [cmd]           Add Husky hook (.husky/pre-commit ""husky run"")
+   husky add <.husky/file> [cmd]           Add Husky hook (.husky/pre-commit ""dotnet husky run"")
    husky run [--name] [--group]            Run task-runner.json tasks
    husky exec <.husky/csx/file.csx>        Execute a csharp script (.csx) file
 

--- a/src/Husky/CliActions.cs
+++ b/src/Husky/CliActions.cs
@@ -88,6 +88,18 @@ public static class CliActions
             "Failed to configure git".LogErr();
             return 1;
          }
+
+         // Configure gitflow repo
+         var local = await Git.ExecBufferedAsync("git config --local --list");
+         if (local.ExitCode == 0 && local.StandardOutput.Contains("gitflow"))
+         {
+            var gf = await Git.ExecAsync($"config gitflow.path.hooks {dir}");
+            if (gf.ExitCode != 0)
+            {
+               "Failed to configure gitflow".LogErr();
+               return 1;
+            }
+         }
       }
       catch (Exception e)
       {

--- a/src/Husky/CliActions.cs
+++ b/src/Husky/CliActions.cs
@@ -66,8 +66,8 @@ public static class CliActions
             await File.WriteAllTextAsync(husky_shPath, content);
          }
 
-         // find all hooks (if exists) from .husky/ and add executable flag (except json files)
-         var files = Directory.GetFiles(path).Where(f => !f.EndsWith(".json")).ToList();
+         // find all hooks (if exists) from .husky/ and add executable flag
+         var files = Directory.GetFiles(path).Where(f => !f.Contains(".")).ToList();
          files.Add(husky_shPath);
          await Utility.SetExecutablePermission(files.ToArray());
 

--- a/src/Husky/Globals.cs
+++ b/src/Husky/Globals.cs
@@ -1,0 +1,9 @@
+namespace Husky;
+
+/// <summary>
+/// Special class to pass variables to the csx files.
+/// </summary>
+public class Globals
+{
+   public IList<string> Args { get; set; }
+}

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -7,7 +7,7 @@
       <Nullable>enable</Nullable>
       <LangVersion>latest</LangVersion>
       <PackageId>Husky</PackageId>
-      <Version>0.0.9</Version>
+      <Version>0.1.0</Version>
       <Title>Husky</Title>
       <Authors>AliReza Sabouri</Authors>
       <Description>Git hooks made easy, woof!</Description>

--- a/src/Husky/Program.cs
+++ b/src/Husky/Program.cs
@@ -10,6 +10,7 @@ while (true)
 
    "\nEnter your husky commands: ".Log();
    var cmd = Console.ReadLine();
+   if (string.IsNullOrEmpty(cmd)) continue;
    // simulating args
    args = Regex.Matches(cmd!, @"[\""].+?[\""]|[^ ]+").Select(m => m.Value.StartsWith("\"") ? m.Value.Replace("\"", "") : m.Value).ToArray();
 #endif

--- a/src/Husky/Utility.cs
+++ b/src/Husky/Utility.cs
@@ -202,7 +202,7 @@ public static class Utility
             if (keyStartIndex == 1) throw new ArgumentException(currentArg);
             // Otherwise, use the switch name directly as a key
 
-            key = currentArg.Substring(keyStartIndex, separator - keyStartIndex);
+            key = currentArg[keyStartIndex..separator];
 
             value = currentArg[(separator + 1)..];
          }


### PR DESCRIPTION
- Add support `#load` in `csx` files
- Add support passing arguments to `csx` files
- Fix executable permission for non-hook files
- Add support gitflow hooks
- CLI - `[cmd]`  is now optional for add/set,  (default is: `dotnet husky run`)