### PR TITLE
v0.1.2 - Bugfixes

### DIFF
--- a/src/Husky/CliActions.cs
+++ b/src/Husky/CliActions.cs
@@ -142,7 +142,7 @@ public static class CliActions
          await using var stream = Assembly.GetAssembly(typeof(Program))!.GetManifestResourceStream("Husky.templates.hook")!;
          using var sr = new StreamReader(stream);
          var content = await sr.ReadToEndAsync();
-         await File.WriteAllTextAsync(file, $"{content}\n{cmd}");
+         await File.WriteAllTextAsync(file, $"{content}\n{cmd}\n");
       }
 
       // needed for linux

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -7,7 +7,7 @@
       <Nullable>enable</Nullable>
       <LangVersion>latest</LangVersion>
       <PackageId>Husky</PackageId>
-      <Version>0.1.1</Version>
+      <Version>0.1.2</Version>
       <Title>Husky</Title>
       <Authors>AliReza Sabouri</Authors>
       <Description>Git hooks made easy, woof!</Description>

--- a/src/Husky/TaskRunner.cs
+++ b/src/Husky/TaskRunner.cs
@@ -265,9 +265,10 @@ public class TaskRunner
             }
             case "${matched}":
             {
-               var files = Directory.GetFiles(await git.GitPath, "*", SearchOption.AllDirectories);
-               var matches = matcher.Match(files);
-               AddMatchedFiles(pathMode, matches, args, await git.GitPath);
+               var gitPath = await git.GitPath;
+               var files = Directory.GetFiles(gitPath, "*", SearchOption.AllDirectories);
+               var matches = matcher.Match(gitPath, files);
+               AddMatchedFiles(pathMode, matches, args, gitPath);
                continue;
             }
             default:


### PR DESCRIPTION
- Bugfix - First husky add some command is not line-terminated. issue #12 PR #13 
- Bugfix - `${matched}` doesn't work on Windows. issue #15 PR #16