### PR TITLE
Fix `${matched}` (Windows) bug returning empty match

### DIFF
--- a/src/Husky/TaskRunner.cs
+++ b/src/Husky/TaskRunner.cs
@@ -265,9 +265,10 @@ public class TaskRunner
             }
             case "${matched}":
             {
-               var files = Directory.GetFiles(await git.GitPath, "*", SearchOption.AllDirectories);
-               var matches = matcher.Match(files);
-               AddMatchedFiles(pathMode, matches, args, await git.GitPath);
+               var gitPath = await git.GitPath;
+               var files = Directory.GetFiles(gitPath, "*", SearchOption.AllDirectories);
+               var matches = matcher.Match(gitPath, files);
+               AddMatchedFiles(pathMode, matches, args, gitPath);
                continue;
             }
             default:


### PR DESCRIPTION
This PR fixes bug reported in issue #15.
