### PR TITLE
v0.2.0 - User-defined variables

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "husky": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "commands": [
         "husky"
       ]

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,5 +1,16 @@
 {
+   "variables": [
+      {
+         "name": "root-dir",
+         "command": "cmd",
+         "args": ["/c", "dir", "/b" ]
+      }
+   ],
    "tasks": [
+      {
+         "command": "cmd",
+         "args": [ "/c", "echo", "${root-dir}" ],
+      },
       {
          "command": "dotnet-format",
          "args": [

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -8,10 +8,6 @@
    ],
    "tasks": [
       {
-         "command": "cmd",
-         "args": [ "/c", "echo", "${root-dir}" ],
-      },
-      {
          "command": "dotnet-format",
          "args": [
             "--include",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can use it to lint your commit messages, run tests, lint code, etc... when y
 **Features**
 
 - 🔥 Internal task runner!
-- 🔥 Multiple file states (staged, lastCommit, glob)
+- 🔥 Multiple file states (staged, committed, lastCommit, glob)
 - 🔥 Compatible with [dotnet-format](https://github.com/dotnet/format)
 - 🔥 Customizable tasks
 - 🔥 Supports task for specific branches
@@ -201,8 +201,10 @@ There are some variables that you can use in your task arguments.
   - returns the list of currently staged files
 - **${LastCommit}**
   - returns last commit changed files
+- **${committed}**
+  - returns the list of committed files (git ls-files)
 - **${matched}**
-  - returns the list of matched files using include and exclude, be careful with this variable, it will return all the files if you don't specify include or exclude
+  - returns the list of matched files using include/exclude, be careful with this variable, it will return all the files if you don't specify include or exclude
 
 e.g.`"args": [ "${staged}" ]`
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ You can use it to lint your commit messages, run tests, lint code, etc... when y
 - 🔥 Compatible with [dotnet-format](https://github.com/dotnet/format)
 - 🔥 Customizable tasks
 - 🔥 Supports task for specific branches
-- 🔥 CSharp scripts (csx)! 🆕
-- 🔥 Supports gitflow hooks 🆕
+- 🔥 CSharp scripts (csx)!
+- 🔥 Supports gitflow hooks
+- 🔥 User-define arg variables 🆕
 - Supports all Git hooks
 - Powered by modern new Git feature (core.hooksPath)
 - User-friendly messages
@@ -193,24 +194,50 @@ Using bellow configuration you can define your task with a lot of options.
 
 ---
 
-### Arg Variables
+## Glob patterns
+
+Husky.Net supports the standard dotnet `FileSystemGlobbing` patterns for include or exclude task configurations. read more [here](https://docs.microsoft.com/en-us/dotnet/core/extensions/file-globbing#pattern-formats)
+
+---
+
+## Arg Variables
 
 There are some variables that you can use in your task arguments.
 
 - **${staged}**
   - returns the list of currently staged files
-- **${LastCommit}**
+- **${last-commit}**
   - returns last commit changed files
-- **${committed}**
-  - returns the list of committed files (git ls-files)
-- **${matched}**
+- **${git-files}**
+  - returns the output of (git ls-files)
+- **${all-files}**
   - returns the list of matched files using include/exclude, be careful with this variable, it will return all the files if you don't specify include or exclude
 
 e.g.`"args": [ "${staged}" ]`
 
-## Glob patterns
+### user-defined variables
 
-Husky.Net supports the standard dotnet `FileSystemGlobbing` patterns for include or exclude task configurations. read more [here](https://docs.microsoft.com/en-us/dotnet/core/extensions/file-globbing#pattern-formats)
+You can define your own variables by adding a task to the `variables` section in `task-runner.json`.
+
+e.g: defining custom `${root-dir}` variable to access root directory files
+
+```json
+{
+   "variables": [
+      {
+         "name": "root-dir",
+         "command": "cmd",
+         "args": ["/c", "dir", "/b"]
+      }
+   ],
+   "tasks": [
+      {
+         "command": "cmd",
+         "args": ["/c", "echo", "${root-dir}"]
+      }
+   ]
+}
+```
 
 ---
 

--- a/src/Husky/Cli.cs
+++ b/src/Husky/Cli.cs
@@ -91,10 +91,10 @@ Options:
 Commands:
    husky install [dir] (default: .husky)   Install Husky hooks
    husky uninstall                         Uninstall Husky hooks
-   husky set <.husky/file> [cmd]           Set Husky hook (.husky/pre-push ""dotnet test"")
-   husky add <.husky/file> [cmd]           Add Husky hook (.husky/pre-commit ""dotnet husky run"")
+   husky set <.husky/file> [cmd]            Set Husky hook (.husky/pre-push ""dotnet test"")
+   husky add <.husky/file> [cmd]            Add Husky hook (.husky/pre-commit ""dotnet husky run"")
    husky run [--name] [--group]            Run task-runner.json tasks
-   husky exec <.husky/csx/file.csx>        Execute a csharp script (.csx) file
+   husky exec <.husky/csx/file.csx> [args]  Execute a csharp script (.csx) file
 
 -- learn more: {CliActions.DOCS_URL}
 ".Log();

--- a/src/Husky/Git.cs
+++ b/src/Husky/Git.cs
@@ -11,10 +11,10 @@ public class Git
    private Lazy<Task<string>> _huskyPath { get; set; }
    private Lazy<Task<string[]>> _stagedFiles { get; set; }
    private Lazy<Task<string[]>> _lastCommitFiles { get; set; }
-   private Lazy<Task<string[]>> _committedFiles { get; set; }
+   private Lazy<Task<string[]>> _GitFiles { get; set; }
 
    public Task<string[]> StagedFiles => _stagedFiles.Value;
-   public Task<string[]> CommittedFiles => _committedFiles.Value;
+   public Task<string[]> GitFiles => _GitFiles.Value;
    public Task<string[]> LastCommitFiles => _lastCommitFiles.Value;
    public Task<string> GitPath => _gitPath.Value;
    public Task<string> GitDirRelativePath => _gitDirRelativePath.Value;
@@ -26,7 +26,7 @@ public class Git
       _gitPath = new Lazy<Task<string>>(GetGitPath);
       _huskyPath = new Lazy<Task<string>>(GetHuskyPath);
       _stagedFiles = new Lazy<Task<string[]>>(GetStagedFiles);
-      _committedFiles = new Lazy<Task<string[]>>(GetCommittedFiles);
+      _GitFiles = new Lazy<Task<string[]>>(GetGitFiles);
       _lastCommitFiles = new Lazy<Task<string[]>>(GetLastCommitFiles);
       _currentBranch = new Lazy<Task<string>>(GetCurrentBranch);
       _gitDirRelativePath = new Lazy<Task<string>>(GetGitDirRelativePath);
@@ -122,7 +122,7 @@ public class Git
          if (result.ExitCode != 0)
             throw new Exception($"Exit code: {result.ExitCode}"); // break execution
 
-         return result.StandardOutput.Trim().Split('\n');
+         return result.StandardOutput.Trim().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
       }
       catch (Exception e)
       {
@@ -150,7 +150,7 @@ public class Git
       }
    }
 
-   private static async Task<string[]> GetCommittedFiles()
+   private static async Task<string[]> GetGitFiles()
    {
       try
       {

--- a/src/Husky/Git.cs
+++ b/src/Husky/Git.cs
@@ -11,8 +11,10 @@ public class Git
    private Lazy<Task<string>> _huskyPath { get; set; }
    private Lazy<Task<string[]>> _stagedFiles { get; set; }
    private Lazy<Task<string[]>> _lastCommitFiles { get; set; }
+   private Lazy<Task<string[]>> _committedFiles { get; set; }
 
    public Task<string[]> StagedFiles => _stagedFiles.Value;
+   public Task<string[]> CommittedFiles => _committedFiles.Value;
    public Task<string[]> LastCommitFiles => _lastCommitFiles.Value;
    public Task<string> GitPath => _gitPath.Value;
    public Task<string> GitDirRelativePath => _gitDirRelativePath.Value;
@@ -24,6 +26,7 @@ public class Git
       _gitPath = new Lazy<Task<string>>(GetGitPath);
       _huskyPath = new Lazy<Task<string>>(GetHuskyPath);
       _stagedFiles = new Lazy<Task<string[]>>(GetStagedFiles);
+      _committedFiles = new Lazy<Task<string[]>>(GetCommittedFiles);
       _lastCommitFiles = new Lazy<Task<string[]>>(GetLastCommitFiles);
       _currentBranch = new Lazy<Task<string>>(GetCurrentBranch);
       _gitDirRelativePath = new Lazy<Task<string>>(GetGitDirRelativePath);
@@ -143,6 +146,24 @@ public class Git
       {
          e.Message.LogVerbose(ConsoleColor.DarkRed);
          "Could not find the staged files".LogErr();
+         throw;
+      }
+   }
+
+   private static async Task<string[]> GetCommittedFiles()
+   {
+      try
+      {
+         var result = await ExecBufferedAsync("ls-files");
+         if (result.ExitCode != 0)
+            throw new Exception($"Exit code: {result.ExitCode}"); // break execution
+
+         return result.StandardOutput.Trim().Split('\n');
+      }
+      catch (Exception e)
+      {
+         e.Message.LogVerbose(ConsoleColor.DarkRed);
+         "Could not find the committed files".LogErr();
          throw;
       }
    }

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -7,7 +7,7 @@
       <Nullable>enable</Nullable>
       <LangVersion>latest</LangVersion>
       <PackageId>Husky</PackageId>
-      <Version>0.1.2</Version>
+      <Version>0.2.0</Version>
       <Title>Husky</Title>
       <Authors>AliReza Sabouri</Authors>
       <Description>Git hooks made easy, woof!</Description>

--- a/src/Husky/TaskRunner.cs
+++ b/src/Husky/TaskRunner.cs
@@ -263,6 +263,14 @@ public class TaskRunner
                AddMatchedFiles(pathMode, matches, args, await git.GitPath);
                continue;
             }
+            case "${committed}":
+            {
+               var committedFiles = await git.CommittedFiles;
+               if (committedFiles.Length < 1) continue;
+               var matches = matcher.Match(committedFiles);
+               AddMatchedFiles(pathMode, matches, args, await git.GitPath);
+               continue;
+            }
             case "${matched}":
             {
                var gitPath = await git.GitPath;

--- a/src/Husky/TaskRunner.cs
+++ b/src/Husky/TaskRunner.cs
@@ -267,6 +267,11 @@ public class TaskRunner
             {
                var gitPath = await git.GitPath;
                var files = Directory.GetFiles(gitPath, "*", SearchOption.AllDirectories);
+
+               // exclude .git directory by default
+               if (task.Exclude is null)
+                  matcher.AddExclude(".git/**");
+
                var matches = matcher.Match(gitPath, files);
                AddMatchedFiles(pathMode, matches, args, gitPath);
                continue;

--- a/src/Husky/TaskRunner.cs
+++ b/src/Husky/TaskRunner.cs
@@ -268,9 +268,9 @@ public class TaskRunner
                var gitPath = await git.GitPath;
                var files = Directory.GetFiles(gitPath, "*", SearchOption.AllDirectories);
 
-               // exclude .git directory by default
-               if (task.Exclude is null)
-                  matcher.AddExclude(".git/**");
+               // exclude .git directory (absolute path)
+               var gitDir = await git.GitDirRelativePath;
+               matcher.AddExclude($"{gitDir}/**");
 
                var matches = matcher.Match(gitPath, files);
                AddMatchedFiles(pathMode, matches, args, gitPath);

--- a/src/Husky/Utility.cs
+++ b/src/Husky/Utility.cs
@@ -74,7 +74,7 @@ public static class Utility
       return await ps.ExecuteAsync();
    }
 
-   private static string GetFullyQualifiedPath(string fileName)
+   public static string GetFullyQualifiedPath(string fileName)
    {
       var fullPath = GetFullPath(fileName);
       return fullPath ?? fileName;


### PR DESCRIPTION
- Exclude `.git` directory for `${matched}` variable by default
- Improve CLI help ([args] added to exec command)
- Add `${committed}` arg variable
- Change `${matched}` to `${all-files}`
- Change `${committed}` to `${git-files}`
- Add user-defined variable support