### PR TITLE
fix: fix execute permission not applied to hooks on linux machines

### DIFF
--- a/src/Husky/Cli/InstallCommand.cs
+++ b/src/Husky/Cli/InstallCommand.cs
@@ -62,7 +62,7 @@ public class InstallCommand : CommandBase
       }
 
       // find all hooks (if exists) from .husky/ and add executable flag
-      var files = Directory.GetFiles(path).Where(f => !f.Contains(".")).ToList();
+      var files = Directory.GetFiles(path).Where(f => !new FileInfo(f).Name.Contains(".")).ToList();
       files.Add(husky_shPath);
       await _cliWrap.SetExecutablePermission(files.ToArray());
 


### PR DESCRIPTION
During an install on a linux system a `chmod +x` command needs to be applied to each hook by the `SetExecutablePermission` method.
The call to `Directory.GetFiles(path).Where(f => !f.Contains("."))` was ignoring any hooks in the husky dir as it was getting the full path and file name for each file. The full path included a dot in the parent folder name `/.husky` causing the file to be skipped. This change inspects only the file name to ensure the hooks are included in the call to SetExecutablePermission.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

