### PR TITLE
Aliasadidev add support for custom args

### DIFF
--- a/docs/guide/task-runner.md
+++ b/docs/guide/task-runner.md
@@ -13,7 +13,9 @@ you can run and test your tasks with `dotnet husky run` command. Once you are su
 e.g
 
 ``` shell:no-line-numbers:no-v-pre
-dotnet husky add pre-commit -c "dotnet husky run"
+stages_files=$(git diff --staged --name-only --no-ext-diff --diff-filter=AM | tr '\n' ';' | sed 's/;$//')
+
+dotnet husky add pre-commit -c "dotnet husky run" --args $stages_files
 ```
 
 ::: details A real-world example.
@@ -81,6 +83,21 @@ dotnet husky add pre-commit -c "dotnet husky run"
             "command": "cmd",
             "args": ["/c", "echo Nice work! 🥂"]
          }
+      },
+      {
+         "name": "Run JB Clean Up Code",
+         "command": "cmd",
+         "pathMode": "relative",
+         "args": [
+           "/c",
+           "dotnet",
+           "jb",
+           "cleanupcode",
+           "proj.sln",
+           "--profile=Team: Full Cleanup",
+           "--include=${args}"
+         ],
+         "group": "pre-commit"
       }
    ]
 }

--- a/docs/guide/task-runner.md
+++ b/docs/guide/task-runner.md
@@ -13,9 +13,7 @@ you can run and test your tasks with `dotnet husky run` command. Once you are su
 e.g
 
 ``` shell:no-line-numbers:no-v-pre
-stages_files=$(git diff --staged --name-only --no-ext-diff --diff-filter=AM | tr '\n' ';' | sed 's/;$//')
-
-dotnet husky add pre-commit -c "dotnet husky run" --args $stages_files
+dotnet husky add pre-commit -c "dotnet husky run"
 ```
 
 ::: details A real-world example.

--- a/src/Husky/TaskRunner/ArgumentParser.cs
+++ b/src/Husky/TaskRunner/ArgumentParser.cs
@@ -41,6 +41,9 @@ public class ArgumentParser : IArgumentParser
             case "${args}":
                AddCustomArguments(args, optionArguments);
                break;
+            case var value when value.Contains("${args}") && optionArguments is not null && optionArguments.Any():
+               args.Add(new ArgumentInfo(ArgumentTypes.Static, value.Replace("${args}", string.Join(' ', optionArguments!))));
+               break;
             case "${last-commit}":
             {
                await AddLastCommit(matcher, args, pathMode);


### PR DESCRIPTION
<!-- Remove the bellow template if your PR is related to the DOCS -->
# Description

Currently, there is no option on **ArgumentParser** class to create an **ArgumentInfo** that supports both **AddCustomArgument** and **AddStaticArgument** in one **Args**, I  added this option.

```json
 {
      "name": "Run JB Clean Up Code",
      "command": "cmd",
      "pathMode": "relative",
      "args": [
        "/c",
        "dotnet",
        "jb",
        "cleanupcode",
        "proj.sln",
        "--profile=Team: Full Cleanup",
        "--include=${args}" <======= added for this usage.
      ],
      "group": "pre-commit"
    }
```

```c#
switch (arg.ToLower().Trim())
{
 case "${args}":
    AddCustomArguments(args, optionArguments);
    break;
 case var value when value.Contains("${args}") && optionArguments is not null && optionArguments.Any():
   args.Add(new ArgumentInfo(ArgumentTypes.Static, value.Replace("${args}", string.Join(' ', optionArguments!))));
   break;
 case "${last-commit}":
//...
```


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I did test corresponding changes on **Windows**
- [x] I did test corresponding changes on **Linux**
- [ ] I did test corresponding changes on **Mac**
