### PR TITLE
docs: Fix for task-runner.md

### DIFF
--- a/docs/guide/task-runner.md
+++ b/docs/guide/task-runner.md
@@ -13,7 +13,7 @@ you can run and test your tasks with `dotnet husky run` command. Once you are su
 e.g
 
 ``` shell:no-line-numbers:no-v-pre
-dotnet husky add pre-commit -c "dotnet husky run"
+dotnet husky add pre-commit -c "dotnet husky run --group pre-commit"
 ```
 
 ::: details A real-world example.


### PR DESCRIPTION
A really minor fix for the docs. but without it, a new user like me would spend some time trying to figure out why when committing a change all the tasks in task.runner.json are running :). 