### PR TITLE
feat(install): git submodule handling

### DIFF
--- a/src/Husky/Services/Contracts/IGit.cs
+++ b/src/Husky/Services/Contracts/IGit.cs
@@ -15,6 +15,21 @@ public interface IGit
    Task<string> GetHuskyPathAsync();
 
    /// <summary>
+   /// Checks if a given path is a submodule.
+   /// <see href="https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---show-superproject-working-tree">relevant git documentation</see>
+   /// </summary>
+   /// <param name="path">path to check</param>
+   /// <returns>true if submodule, false otherwise.</returns>
+   Task<bool> IsSubmodule(string path);
+
+   /// <summary>
+   /// Returns the path to the `.git` directory
+   /// </summary>
+   /// <param name="path">Target path for the git command</param>
+   /// <returns>Path to .git directory if found.</returns>
+   Task<string> GetGitDirectory(string path);
+
+   /// <summary>
    /// only file additions and modifications
    /// </summary>
    /// <returns></returns>

--- a/src/Husky/Services/Git.cs
+++ b/src/Husky/Services/Git.cs
@@ -85,6 +85,46 @@ public class Git : IGit
       return await _huskyPath;
    }
 
+   /// <inheritdoc/>
+   /// <exception cref="Exception">Command exited in non zero code</exception>
+   /// <exception cref="CommandException">Exception while executing command</exception>
+   public async Task<bool> IsSubmodule(string path)
+   {
+      try
+      {
+         var result = await ExecBufferedAsync($"-C {path} rev-parse --show-superproject-working-tree");
+         if (result.ExitCode != 0)
+            throw new Exception($"Failed to determine git configuration: {result.ExitCode}");
+
+         return !string.IsNullOrWhiteSpace(result.StandardOutput);
+      }
+      catch (Exception e)
+      {
+         e.Message.LogVerbose(ConsoleColor.DarkRed);
+         throw new CommandException("Could not determine git configuration", innerException: e);
+      }
+   }
+
+   /// <inheritdoc/>
+   /// <exception cref="Exception">Command exited in non zero code</exception>
+   /// <exception cref="CommandException">Exception while executing command</exception>
+   public async Task<string> GetGitDirectory(string path)
+   {
+      try
+      {
+         var result = await ExecBufferedAsync($"-C {path} rev-parse --git-dir");
+         if (result.ExitCode != 0)
+            throw new Exception($"Failed to determine .git directory path: {result.ExitCode}");
+
+         return result.StandardOutput.Trim();
+      }
+      catch (Exception e)
+      {
+         e.Message.LogVerbose(ConsoleColor.DarkRed);
+         throw new CommandException("Could not determine .git directory path", innerException: e);
+      }
+   }
+
    public async Task<string[]> GetDiffStagedRecord()
    {
       try

--- a/tests/HuskyTest/Cli/InstallCommandTests.cs
+++ b/tests/HuskyTest/Cli/InstallCommandTests.cs
@@ -70,7 +70,7 @@ namespace HuskyTest.Cli
          var now = DateTimeOffset.Now;
          _git.ExecAsync("rev-parse").Returns(Task.FromResult(new CommandResult(0, now, now)));
          _fileSystem.Directory.Exists(Path.Combine(Environment.CurrentDirectory, ".git")).Returns(false);
-         _git.ExecBufferedAsync("rev-parse --git-dir").Returns(new BufferedCommandResult(0, now, now, "C:\\TestPath\\.git\\worktrees\\branch", ""));
+         _git.GetGitDirectory(Arg.Any<string>()).Returns(@"C:\TestPath\.git\worktrees\branch", "");
          _git.ExecAsync("config core.hooksPath .husky").Returns(Task.FromResult(new CommandResult(0, now, now)));
          _git.ExecBufferedAsync("config --local --list").Returns(new BufferedCommandResult(0, now, now, "gitflow", ""));
          _git.ExecAsync("config gitflow.path.hooks .husky").Returns(Task.FromResult(new CommandResult(0, now, now)));


### PR DESCRIPTION
<!-- Remove the bellow template if your PR is related to the DOCS -->
# Description

Husky so far is unable to handle `install` on submodules. This PR attempts to solve that by adding:
1. `IgnoreSubmodule` option to both `attach` and `install` which will either prevent the whole target from being executed (same as Husku = 1) or in the case of install make it break the installation process if it detects it's a submodule.
2. When `IgnoreSubdmoule` is not specified the install command will then attach the husky hooks to the correct `.git` directory which is not `.git` in the case of submodules.

See more details here #69 

Fixes issue (#69)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] I did test corresponding changes on **Windows**
- [ ] I did test corresponding changes on **Linux**
- [ ] I did test corresponding changes on **Mac**
