### PR TITLE
Add support for .NET 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
       steps:
          -  name: Checkout code
             uses: actions/checkout@v3
-         -  name: Setup .NET 8
+         -  name: Setup .NET 9
             uses: actions/setup-dotnet@v3
             with:
-               dotnet-version: 8.0.100
+               dotnet-version: 9.0.x
          -  name: Restore dependencies
             run: dotnet restore
          -  name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
          -  name: Checkout code
             uses: actions/checkout@v3
 
-         -  name: Setup .NET 8
+         -  name: Setup .NET 9
             uses: actions/setup-dotnet@v3
             with:
-               dotnet-version: 8.0.x
+               dotnet-version: 9.0.x
          -  name: Print information
             run: |
                ls -la

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/tests/HuskyIntegrationTests/HuskyIntegrationTests.csproj
+++ b/tests/HuskyIntegrationTests/HuskyIntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/tests/HuskyTest/HuskyTest.csproj
+++ b/tests/HuskyTest/HuskyTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
    <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
+      <TargetFramework>net9.0</TargetFramework>
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
    </PropertyGroup>


### PR DESCRIPTION
# Description

.NET 9 is now GA, so add support for it:
- added `net9.0` to target frameworks of the package project (keeping older versions as well, so it should not break existing users)
- bumped test code projects to `net9.0`
- adjusted build and publish workflow to use `net9.0`

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have performed a self-review of my code
- [X] I did test corresponding changes on **Windows**
