### PR TITLE
fix: update regex pattern to allow breaking commits

### DIFF
--- a/.husky/csx/commit-lint.csx
+++ b/.husky/csx/commit-lint.csx
@@ -6,7 +6,7 @@
 
 using System.Text.RegularExpressions;
 
-private var pattern = @"^(?=.{1,90}$)(?:build|feat|ci|chore|docs|fix|perf|refactor|revert|style|test)(?:\(.+\))*(?::).{4,}(?:#\d+)*(?<![\.\s])$";
+private var pattern = @"^(?=.{1,90}$)(?:build|feat|ci|chore|docs|fix|perf|refactor|revert|style|test)(?:\(.+\))*!?(?::).{4,}(?:#\d+)*(?<![\.\s])$";
 private var msg = File.ReadAllLines(Args[0])[0];
 
 if (Regex.IsMatch(msg, pattern))


### PR DESCRIPTION
# Description

The current pattern doesn't support the ! marker for breaking changes, which is a key part of conventional commits (e.g., `feat!: breaking change` or `feat(scope)!: breaking change`).



Fixes # (issue)

he pattern now includes !? after the optional scope, which allows for breaking change commits. Now these formats are all valid:

`feat: regular commit`
`feat(scope): scoped commit`
`feat!: breaking change`
`feat(scope)!: breaking change with scope`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I did test corresponding changes on **Windows**
- [x] I did test corresponding changes on **Linux**
- [ ] I did test corresponding changes on **Mac**
