### PR TITLE
Fix Touch race condition on first run with parallel MSBuild nodes

### DIFF
--- a/docs/guide/automate.md
+++ b/docs/guide/automate.md
@@ -31,7 +31,8 @@ To manually attach husky to your project, add the below code to one of your proj
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High"
          WorkingDirectory="../../" />  <!--Update this to the relative path to your project root dir -->
-   <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true" />
+   <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true"
+          Condition="Exists('../../.husky/_')" />
    <ItemGroup>
       <FileWrites Include="../../.husky/_/install.stamp" />
    </ItemGroup>

--- a/docs/guide/submodules.md
+++ b/docs/guide/submodules.md
@@ -34,10 +34,17 @@ The `attach` command offers a `--ignore-submodule` options that generates an MsB
 The generated block will look something like this, If you're attaching husky manually copy the target to your `.csproj` and adjust `WorkingDirectory` accordingly.
 
 ```xml:no-line-numbers:no-v-pre
-<Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0">
+<Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0"
+        Inputs="../../.config/dotnet-tools.json"
+        Outputs="../../.husky/_/install.stamp">
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
    <Exec Command="dotnet husky install --ignore-submodule" StandardOutputImportance="Low" StandardErrorImportance="High"
          WorkingDirectory="../../" />  <!--Update this to the relative path to your project root dir -->
+   <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true"
+          Condition="Exists('../../.husky/_')" />
+   <ItemGroup>
+      <FileWrites Include="../../.husky/_/install.stamp" />
+   </ItemGroup>
 </Target>
 ```
 

--- a/src/Husky/Cli/AttachCommand.cs
+++ b/src/Husky/Cli/AttachCommand.cs
@@ -83,9 +83,11 @@ public class AttachCommand : CommandBase
       exec.SetAttributeValue("WorkingDirectory", rootRelativePath);
       target.Add(exec);
 
+      var huskyDir = Path.Combine(rootRelativePath, ".husky", "_");
       var touch = new XElement("Touch");
       touch.SetAttributeValue("Files", sentinelPath);
       touch.SetAttributeValue("AlwaysCreate", "true");
+      touch.SetAttributeValue("Condition", $"Exists('{huskyDir}')");
       target.Add(touch);
 
       var itemGroup = new XElement("ItemGroup");

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -68,12 +68,12 @@
     <Compile Remove="Utils\Dotnet\ParallelETWProvider.cs" />
     <Compile Remove="Utils\Dotnet\Parallel.cs" />
   </ItemGroup>
-  <Target Name="Husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != 0 and '$(IsCrossTargetingBuild)' == 'true'"
+  <Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0 and '$(IsCrossTargetingBuild)' == 'true'"
           Inputs="../../.config/dotnet-tools.json"
           Outputs="../../.husky/_/install.stamp">
     <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
-    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="..\.." />
-    <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true" />
+    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="../../"/>
+    <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('../../.husky/_')" />
     <ItemGroup>
       <FileWrites Include="../../.husky/_/install.stamp" />
     </ItemGroup>

--- a/tests/HuskyTest/Cli/AttachCommandTests.cs
+++ b/tests/HuskyTest/Cli/AttachCommandTests.cs
@@ -61,14 +61,16 @@ public class AttachCommandTests
       huskyTarget!.Descendants("Exec").Should().HaveCount(2);
       huskyTarget.Attribute("Inputs").Should().NotBeNull();
       huskyTarget.Attribute("Outputs").Should().NotBeNull();
+
+      // Verify Touch is conditioned on directory existence
       huskyTarget.Descendants("Touch").Should().HaveCount(1);
-      huskyTarget.Descendants("Touch").First().Attribute("AlwaysCreate")?.Value.Should().Be("true");
+      var touch = huskyTarget.Descendants("Touch").First();
+      touch.Attribute("AlwaysCreate")?.Value.Should().Be("true");
+      touch.Attribute("Condition")?.Value.Should().Contain("Exists(");
+
       huskyTarget.Descendants("ItemGroup").Descendants("FileWrites").Should().HaveCount(1);
 
       _console.ReadOutputString().Trim().Should().Be("Husky dev-dependency successfully attached to this project.");
-
-      huskyTarget.Attribute("AfterTargets")?.Value.Should().Be("Restore");
-      huskyTarget.Attribute("BeforeTargets").Should().BeNull();
    }
 
    [Fact]


### PR DESCRIPTION
# Description

When multiple MSBuild nodes run `dotnet husky install` concurrently on first checkout (e.g., via `Directory.Build.targets`), the mutex losers skip the install but the `Touch` task still tries to create `install.stamp` in the `.husky/_/` directory. Since that directory hasn't been created yet (the winner is still working), this fails with:

```
error MSB3371: The file ".husky/_/install.stamp" cannot be created.
Could not find a part of the path '.husky/_/install.stamp'.
```

Who's impacted:

 - Users who adopted the new incremental target (v0.9.0 via dotnet husky attach or docs snippet)
 - In a solution with multiple projects (where MSBuild runs parallel restore)
 - Only on first build after a fresh checkout (before .husky/_/ exists)

Not impacted:

 - Users with the old target (no Touch task)
 - Single-project solutions (no parallelism)
 - Any build after the first successful one (directory exists, Touch condition passes)

Fixes #155

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have made corresponding changes to the documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] I did test corresponding changes on **Windows**
- [X] I did test corresponding changes on **Linux**
- [ ] I did test corresponding changes on **Mac**
