### PR TITLE
Define HuskyRoot property to avoid repeating paths in MSBuild target

### DIFF
--- a/docs/guide/automate.md
+++ b/docs/guide/automate.md
@@ -29,7 +29,7 @@ To manually attach husky to your project, add the below code to one of your proj
    <!-- Update this to the relative path from your project to the repo root -->
    <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
 </PropertyGroup>
-<Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0"
+<Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0"
         Inputs="$(HuskyRoot).config/dotnet-tools.json"
         Outputs="$(HuskyRoot).husky/_/install.stamp">
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
@@ -64,7 +64,7 @@ to avoid this, you can add the `$(IsCrossTargetingBuild)' == 'true'` condition t
 e.g
 
 ``` xml:no-line-numbers:no-v-pre
-<Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0 and '$(IsCrossTargetingBuild)' == 'true'">
+<Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0 and '$(IsCrossTargetingBuild)' == 'true'">
 ...
 ```
 

--- a/docs/guide/automate.md
+++ b/docs/guide/automate.md
@@ -52,7 +52,7 @@ The target uses MSBuild incremental build support (`Inputs`/`Outputs`) to avoid 
 :::
 
 ::: tip
-For solutions with multiple projects, consider placing the target in a `Directory.Build.targets` file at the repository root. When placed at the root, set `HuskyRoot` to `$(MSBuildThisFileDirectory)` and all paths resolve automatically with no manual configuration. Do not use `Directory.Build.props` for this - targets belong in `.targets` files.
+For solutions with multiple projects, consider placing the target in a `Directory.Build.targets` file at the repository root. When placed at the root, set `HuskyRoot` to `$(MSBuildThisFileDirectory)` and all paths resolve automatically with no manual configuration. Do not use `Directory.Build.props` for this; targets belong in `.targets` files.
 :::
 
 ::: warning

--- a/docs/guide/automate.md
+++ b/docs/guide/automate.md
@@ -25,22 +25,25 @@ You can set the `HUSKY` environment variable to `0` in order to disable husky in
 To manually attach husky to your project, add the below code to one of your projects (*.csproj/*.vbproj).
 
 ``` xml:no-line-numbers:no-v-pre
+<PropertyGroup>
+   <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
+</PropertyGroup>
 <Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0"
-        Inputs="../../.config/dotnet-tools.json"
-        Outputs="../../.husky/_/install.stamp">
+        Inputs="$(HuskyRoot).config/dotnet-tools.json"
+        Outputs="$(HuskyRoot).husky/_/install.stamp">
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High"
-         WorkingDirectory="../../" />  <!--Update this to the relative path to your project root dir -->
-   <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true"
-          Condition="Exists('../../.husky/_')" />
+         WorkingDirectory="$(HuskyRoot)" />
+   <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true"
+          Condition="Exists('$(HuskyRoot).husky/_')" />
    <ItemGroup>
-      <FileWrites Include="../../.husky/_/install.stamp" />
+      <FileWrites Include="$(HuskyRoot).husky/_/install.stamp" />
    </ItemGroup>
 </Target>
 ```
 
 ::: tip
-Make sure to update the working directory and the `Inputs`/`Outputs`/`Touch`/`FileWrites` paths depending on your folder structure. All paths should be relative to your project and point to the repository root dir.
+Update the `HuskyRoot` property value to match the relative path from your project to the repository root directory (with a trailing slash). All other paths derive from it automatically.
 :::
 
 ::: tip
@@ -48,7 +51,7 @@ The target uses MSBuild incremental build support (`Inputs`/`Outputs`) to avoid 
 :::
 
 ::: tip
-For solutions with multiple projects, consider placing the target in a `Directory.Build.targets` file at the repository root. When placed at the root, you can replace relative paths (e.g. `../../`) with `$(MSBuildThisFileDirectory)` which resolves to the directory containing the targets file.
+For solutions with multiple projects, consider placing the target in a `Directory.Build.targets` file at the repository root. When placed at the root, set `HuskyRoot` to `$(MSBuildThisFileDirectory)` and all paths resolve automatically with no manual configuration. Do not use `Directory.Build.props` for this - targets belong in `.targets` files.
 :::
 
 ::: warning

--- a/docs/guide/automate.md
+++ b/docs/guide/automate.md
@@ -26,6 +26,7 @@ To manually attach husky to your project, add the below code to one of your proj
 
 ``` xml:no-line-numbers:no-v-pre
 <PropertyGroup>
+   <!-- Update this to the relative path from your project to the repo root -->
    <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
 </PropertyGroup>
 <Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0"

--- a/docs/guide/submodules.md
+++ b/docs/guide/submodules.md
@@ -38,7 +38,7 @@ The generated block will look something like this, If you're attaching husky man
    <!-- Update this to the relative path from your project to the repo root -->
    <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
 </PropertyGroup>
-<Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0"
+<Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0"
         Inputs="$(HuskyRoot).config/dotnet-tools.json"
         Outputs="$(HuskyRoot).husky/_/install.stamp">
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>

--- a/docs/guide/submodules.md
+++ b/docs/guide/submodules.md
@@ -31,19 +31,22 @@ Submodule detected and [--ignore-when-submodule] is set, skipping install target
 
 The `attach` command offers a `--ignore-submodule` options that generates an MsBuild target you can skip by setting the `IgnoreSubmodule` variable to `0` similar to the `Husky` variable, see [Disable husky in CI/CD pipelines](./automate.md#disable-husky-in-ci-cd-pipelines)
 
-The generated block will look something like this, If you're attaching husky manually copy the target to your `.csproj` and adjust `WorkingDirectory` accordingly.
+The generated block will look something like this, If you're attaching husky manually copy the target to your `.csproj` and adjust `HuskyRoot` accordingly.
 
 ```xml:no-line-numbers:no-v-pre
+<PropertyGroup>
+   <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
+</PropertyGroup>
 <Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0"
-        Inputs="../../.config/dotnet-tools.json"
-        Outputs="../../.husky/_/install.stamp">
+        Inputs="$(HuskyRoot).config/dotnet-tools.json"
+        Outputs="$(HuskyRoot).husky/_/install.stamp">
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
    <Exec Command="dotnet husky install --ignore-submodule" StandardOutputImportance="Low" StandardErrorImportance="High"
-         WorkingDirectory="../../" />  <!--Update this to the relative path to your project root dir -->
-   <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true"
-          Condition="Exists('../../.husky/_')" />
+         WorkingDirectory="$(HuskyRoot)" />
+   <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true"
+          Condition="Exists('$(HuskyRoot).husky/_')" />
    <ItemGroup>
-      <FileWrites Include="../../.husky/_/install.stamp" />
+      <FileWrites Include="$(HuskyRoot).husky/_/install.stamp" />
    </ItemGroup>
 </Target>
 ```

--- a/docs/guide/submodules.md
+++ b/docs/guide/submodules.md
@@ -35,6 +35,7 @@ The generated block will look something like this, If you're attaching husky man
 
 ```xml:no-line-numbers:no-v-pre
 <PropertyGroup>
+   <!-- Update this to the relative path from your project to the repo root -->
    <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
 </PropertyGroup>
 <Target Name="husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0"

--- a/src/Husky/Cli/AttachCommand.cs
+++ b/src/Husky/Cli/AttachCommand.cs
@@ -46,15 +46,15 @@ public class AttachCommand : CommandBase
          return;
       }
 
-      // If husky target tag exists, remove it
-      if (huskyTarget != null && Force)
-      {
-         huskyTarget.Remove();
-         // Also remove existing HuskyRoot PropertyGroup to avoid duplicates
-         doc.Descendants("PropertyGroup")
-            .FirstOrDefault(pg => pg.Descendants("HuskyRoot").Any())
-            ?.Remove();
-      }
+      // Remove existing husky elements to avoid duplicates
+      doc.Descendants("Target")
+         .Where(q => q.Attribute("Name")?.Value.Equals("Husky", StringComparison.InvariantCultureIgnoreCase) ?? false)
+         .ToList()
+         .ForEach(e => e.Remove());
+      doc.Descendants("PropertyGroup")
+         .Where(pg => pg.Descendants("HuskyRoot").Any())
+         .ToList()
+         .ForEach(e => e.Remove());
 
       // create husky target
       var condition = GetCondition(doc);

--- a/src/Husky/Cli/AttachCommand.cs
+++ b/src/Husky/Cli/AttachCommand.cs
@@ -48,29 +48,49 @@ public class AttachCommand : CommandBase
 
       // If husky target tag exists, remove it
       if (huskyTarget != null && Force)
+      {
          huskyTarget.Remove();
+         // Also remove existing HuskyRoot PropertyGroup to avoid duplicates
+         doc.Descendants("PropertyGroup")
+            .FirstOrDefault(pg => pg.Descendants("HuskyRoot").Any())
+            ?.Remove();
+      }
 
       // create husky target
       var condition = GetCondition(doc);
       var rootRelativePath = await GetRelativePath(filepath);
-      var target = GetTarget(condition, rootRelativePath);
+      var propertyGroup = GetHuskyRootPropertyGroup(rootRelativePath);
+      var target = GetTarget(condition);
+      doc.Add(propertyGroup);
       doc.Add(target);
       _xmlIo.Save(filepath, doc);
 
       "Husky dev-dependency successfully attached to this project.".Log(ConsoleColor.Green);
    }
 
-   private XElement GetTarget(string condition, string rootRelativePath)
+   private XElement GetHuskyRootPropertyGroup(string rootRelativePath)
    {
-      var sentinelPath = Path.Combine(rootRelativePath, ".husky", "_", "install.stamp");
-      var inputPath = Path.Combine(rootRelativePath, ".config", "dotnet-tools.json");
+      // Normalize to forward slashes and ensure trailing slash for MSBuild string concatenation
+      var huskyRoot = rootRelativePath
+         .Replace(Path.DirectorySeparatorChar, '/')
+         .TrimEnd('/')
+         + "/";
 
+      var propertyGroup = new XElement("PropertyGroup");
+      var huskyRootElement = new XElement("HuskyRoot", huskyRoot);
+      huskyRootElement.SetAttributeValue("Condition", "'$(HuskyRoot)' == ''");
+      propertyGroup.Add(huskyRootElement);
+      return propertyGroup;
+   }
+
+   private XElement GetTarget(string condition)
+   {
       var target = new XElement("Target");
       target.SetAttributeValue("Name", "Husky");
       target.SetAttributeValue("AfterTargets", "Restore");
       target.SetAttributeValue("Condition", condition);
-      target.SetAttributeValue("Inputs", inputPath);
-      target.SetAttributeValue("Outputs", sentinelPath);
+      target.SetAttributeValue("Inputs", "$(HuskyRoot).config/dotnet-tools.json");
+      target.SetAttributeValue("Outputs", "$(HuskyRoot).husky/_/install.stamp");
       var exec = new XElement("Exec");
       exec.SetAttributeValue("Command", "dotnet tool restore");
       exec.SetAttributeValue("StandardOutputImportance", "Low");
@@ -80,19 +100,18 @@ public class AttachCommand : CommandBase
       exec.SetAttributeValue("Command", GetInstallCommand());
       exec.SetAttributeValue("StandardOutputImportance", "Low");
       exec.SetAttributeValue("StandardErrorImportance", "High");
-      exec.SetAttributeValue("WorkingDirectory", rootRelativePath);
+      exec.SetAttributeValue("WorkingDirectory", "$(HuskyRoot)");
       target.Add(exec);
 
-      var huskyDir = Path.Combine(rootRelativePath, ".husky", "_");
       var touch = new XElement("Touch");
-      touch.SetAttributeValue("Files", sentinelPath);
+      touch.SetAttributeValue("Files", "$(HuskyRoot).husky/_/install.stamp");
       touch.SetAttributeValue("AlwaysCreate", "true");
-      touch.SetAttributeValue("Condition", $"Exists('{huskyDir}')");
+      touch.SetAttributeValue("Condition", "Exists('$(HuskyRoot).husky/_')");
       target.Add(touch);
 
       var itemGroup = new XElement("ItemGroup");
       var fileWrites = new XElement("FileWrites");
-      fileWrites.SetAttributeValue("Include", sentinelPath);
+      fileWrites.SetAttributeValue("Include", "$(HuskyRoot).husky/_/install.stamp");
       itemGroup.Add(fileWrites);
       target.Add(itemGroup);
 

--- a/src/Husky/Cli/AttachCommand.cs
+++ b/src/Husky/Cli/AttachCommand.cs
@@ -57,19 +57,17 @@ public class AttachCommand : CommandBase
          .ForEach(e => e.Remove());
 
       // create husky target
-      var condition = GetCondition(doc);
-      var rootRelativePath = await GetRelativePath(filepath);
-      var propertyGroup = GetHuskyRootPropertyGroup(rootRelativePath);
-      var target = GetTarget(condition);
-      doc.Add(propertyGroup);
-      doc.Add(target);
+      await AddHuskyTarget(doc, filepath);
       _xmlIo.Save(filepath, doc);
 
       "Husky dev-dependency successfully attached to this project.".Log(ConsoleColor.Green);
    }
 
-   private XElement GetHuskyRootPropertyGroup(string rootRelativePath)
+   private async Task AddHuskyTarget(XContainer doc, string filepath)
    {
+      var condition = GetCondition(doc);
+      var rootRelativePath = await GetRelativePath(filepath);
+
       // Normalize to forward slashes and ensure trailing slash for MSBuild string concatenation
       var huskyRoot = rootRelativePath
          .Replace(Path.DirectorySeparatorChar, '/')
@@ -80,11 +78,8 @@ public class AttachCommand : CommandBase
       var huskyRootElement = new XElement("HuskyRoot", huskyRoot);
       huskyRootElement.SetAttributeValue("Condition", "'$(HuskyRoot)' == ''");
       propertyGroup.Add(huskyRootElement);
-      return propertyGroup;
-   }
+      doc.Add(propertyGroup);
 
-   private XElement GetTarget(string condition)
-   {
       var target = new XElement("Target");
       target.SetAttributeValue("Name", "Husky");
       target.SetAttributeValue("AfterTargets", "Restore");
@@ -115,7 +110,7 @@ public class AttachCommand : CommandBase
       itemGroup.Add(fileWrites);
       target.Add(itemGroup);
 
-      return target;
+      doc.Add(target);
    }
 
    private string GetInstallCommand()

--- a/src/Husky/Cli/AttachCommand.cs
+++ b/src/Husky/Cli/AttachCommand.cs
@@ -47,14 +47,22 @@ public class AttachCommand : CommandBase
       }
 
       // Remove existing husky elements to avoid duplicates
-      doc.Descendants("Target")
+      foreach (var target in doc.Descendants("Target")
          .Where(q => q.Attribute("Name")?.Value.Equals("Husky", StringComparison.InvariantCultureIgnoreCase) ?? false)
-         .ToList()
-         .ForEach(e => e.Remove());
-      doc.Descendants("PropertyGroup")
-         .Where(pg => pg.Descendants("HuskyRoot").Any())
-         .ToList()
-         .ForEach(e => e.Remove());
+         .ToList())
+      {
+         target.Remove();
+      }
+
+      foreach (var huskyRoot in doc.Descendants("HuskyRoot").ToList())
+      {
+         var pg = huskyRoot.Parent;
+         huskyRoot.Remove();
+         if (pg is { HasElements: false })
+         {
+            pg.Remove();
+         }
+      }
 
       // create husky target
       await AddHuskyTarget(doc, filepath);

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -68,14 +68,17 @@
     <Compile Remove="Utils\Dotnet\ParallelETWProvider.cs" />
     <Compile Remove="Utils\Dotnet\Parallel.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
+  </PropertyGroup>
   <Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0 and '$(IsCrossTargetingBuild)' == 'true'"
-          Inputs="../../.config/dotnet-tools.json"
-          Outputs="../../.husky/_/install.stamp">
+          Inputs="$(HuskyRoot).config/dotnet-tools.json"
+          Outputs="$(HuskyRoot).husky/_/install.stamp">
     <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
-    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="../../"/>
-    <Touch Files="../../.husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('../../.husky/_')" />
+    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(HuskyRoot)"/>
+    <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('$(HuskyRoot).husky/_')" />
     <ItemGroup>
-      <FileWrites Include="../../.husky/_/install.stamp" />
+      <FileWrites Include="$(HuskyRoot).husky/_/install.stamp" />
     </ItemGroup>
   </Target>
 

--- a/tests/HuskyTest/Cli/AttachCommandTests.cs
+++ b/tests/HuskyTest/Cli/AttachCommandTests.cs
@@ -55,6 +55,13 @@ public class AttachCommandTests
       _xmlIo.Received(1).Load(Arg.Any<string>());
       _xmlIo.Received(1).Save(Arg.Any<string>(), Arg.Is(_xmlDoc));
 
+      // Verify HuskyRoot PropertyGroup
+      var huskyRoot = _xmlDoc.Descendants("PropertyGroup")
+         .SelectMany(pg => pg.Descendants("HuskyRoot"))
+         .FirstOrDefault();
+      huskyRoot.Should().NotBeNull();
+      huskyRoot!.Attribute("Condition")?.Value.Should().Be("'$(HuskyRoot)' == ''");
+
       var huskyTarget = _xmlDoc.Descendants("Target")
          .FirstOrDefault(q => q.Attribute("Name")?.Value == "Husky");
       huskyTarget.Should().NotBeNull();
@@ -177,22 +184,27 @@ public class AttachCommandTests
       // Assert
       _xmlIo.Received(1).Save(Arg.Any<string>(), Arg.Any<XElement>());
 
+      // Verify HuskyRoot property has the correct relative path with trailing slash
+      var expectedHuskyRoot = string.Join("/", relativePath) + "/";
+      var huskyRoot = _xmlDoc.Descendants("PropertyGroup")
+         .SelectMany(pg => pg.Descendants("HuskyRoot"))
+         .FirstOrDefault();
+      huskyRoot.Should().NotBeNull();
+      huskyRoot!.Value.Should().Be(expectedHuskyRoot);
+
+      // Verify Target uses $(HuskyRoot) references, not literal paths
       var huskyTarget = _xmlDoc.Descendants("Target")
          .FirstOrDefault(q => q.Attribute("Name")?.Value == "Husky");
       huskyTarget.Should().NotBeNull();
 
-      var rootRelativePath = string.Join(Path.DirectorySeparatorChar, relativePath);
-
       var exec = huskyTarget!.Descendants("Exec")
-         .FirstOrDefault(q => q.Attribute("Command")?.Value == "dotnet husky install");
+         .FirstOrDefault(q => q.Attribute("Command")?.Value.Contains("dotnet husky install") == true);
       exec.Should().NotBeNull();
-      exec!.Attribute("WorkingDirectory")?.Value.Should().Be(rootRelativePath);
+      exec!.Attribute("WorkingDirectory")?.Value.Should().Be("$(HuskyRoot)");
 
-      var expectedSentinel = Path.Combine(rootRelativePath, ".husky", "_", "install.stamp");
-      var expectedInput = Path.Combine(rootRelativePath, ".config", "dotnet-tools.json");
-      huskyTarget.Attribute("Inputs")?.Value.Should().Be(expectedInput);
-      huskyTarget.Attribute("Outputs")?.Value.Should().Be(expectedSentinel);
-      huskyTarget.Descendants("Touch").First().Attribute("Files")?.Value.Should().Be(expectedSentinel);
-      huskyTarget.Descendants("ItemGroup").Descendants("FileWrites").First().Attribute("Include")?.Value.Should().Be(expectedSentinel);
+      huskyTarget.Attribute("Inputs")?.Value.Should().Be("$(HuskyRoot).config/dotnet-tools.json");
+      huskyTarget.Attribute("Outputs")?.Value.Should().Be("$(HuskyRoot).husky/_/install.stamp");
+      huskyTarget.Descendants("Touch").First().Attribute("Files")?.Value.Should().Be("$(HuskyRoot).husky/_/install.stamp");
+      huskyTarget.Descendants("ItemGroup").Descendants("FileWrites").First().Attribute("Include")?.Value.Should().Be("$(HuskyRoot).husky/_/install.stamp");
    }
 }

--- a/tests/HuskyTest/Cli/AttachCommandTests.cs
+++ b/tests/HuskyTest/Cli/AttachCommandTests.cs
@@ -184,27 +184,22 @@ public class AttachCommandTests
       // Assert
       _xmlIo.Received(1).Save(Arg.Any<string>(), Arg.Any<XElement>());
 
-      // Verify HuskyRoot property has the correct relative path with trailing slash
       var expectedHuskyRoot = string.Join("/", relativePath) + "/";
-      var huskyRoot = _xmlDoc.Descendants("PropertyGroup")
-         .SelectMany(pg => pg.Descendants("HuskyRoot"))
-         .FirstOrDefault();
-      huskyRoot.Should().NotBeNull();
-      huskyRoot!.Value.Should().Be(expectedHuskyRoot);
+      var expected = XElement.Parse(
+         $$"""
+         <Project Sdk="Microsoft.NET.Sdk">
+           <PropertyGroup><TargetFramework>netcoreapp2.1</TargetFramework></PropertyGroup>
+           <PropertyGroup><HuskyRoot Condition="'$(HuskyRoot)' == ''">{{expectedHuskyRoot}}</HuskyRoot></PropertyGroup>
+           <Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0"
+                   Inputs="$(HuskyRoot).config/dotnet-tools.json" Outputs="$(HuskyRoot).husky/_/install.stamp">
+             <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
+             <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(HuskyRoot)" />
+             <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('$(HuskyRoot).husky/_')" />
+             <ItemGroup><FileWrites Include="$(HuskyRoot).husky/_/install.stamp" /></ItemGroup>
+           </Target>
+         </Project>
+         """);
 
-      // Verify Target uses $(HuskyRoot) references, not literal paths
-      var huskyTarget = _xmlDoc.Descendants("Target")
-         .FirstOrDefault(q => q.Attribute("Name")?.Value == "Husky");
-      huskyTarget.Should().NotBeNull();
-
-      var exec = huskyTarget!.Descendants("Exec")
-         .FirstOrDefault(q => q.Attribute("Command")?.Value.Contains("dotnet husky install") == true);
-      exec.Should().NotBeNull();
-      exec!.Attribute("WorkingDirectory")?.Value.Should().Be("$(HuskyRoot)");
-
-      huskyTarget.Attribute("Inputs")?.Value.Should().Be("$(HuskyRoot).config/dotnet-tools.json");
-      huskyTarget.Attribute("Outputs")?.Value.Should().Be("$(HuskyRoot).husky/_/install.stamp");
-      huskyTarget.Descendants("Touch").First().Attribute("Files")?.Value.Should().Be("$(HuskyRoot).husky/_/install.stamp");
-      huskyTarget.Descendants("ItemGroup").Descendants("FileWrites").First().Attribute("Include")?.Value.Should().Be("$(HuskyRoot).husky/_/install.stamp");
+      _xmlDoc.ToString().Should().Be(expected.ToString());
    }
 }

--- a/tests/HuskyTest/Cli/AttachCommandTests.cs
+++ b/tests/HuskyTest/Cli/AttachCommandTests.cs
@@ -117,6 +117,27 @@ public class AttachCommandTests
    }
 
    [Fact]
+   public async Task Attach_WhenForceIsTrue_ShouldPreserveOtherPropertiesInPropertyGroup()
+   {
+      // Arrange - HuskyRoot shares a PropertyGroup with another property
+      _console = new FakeInMemoryConsole();
+      _xmlDoc.Add(new XElement("Target", new XAttribute("Name", "Husky")));
+      var sharedPg = new XElement("PropertyGroup",
+         new XElement("SomeOtherProperty", "value"),
+         new XElement("HuskyRoot", "../../"));
+      _xmlDoc.Add(sharedPg);
+      var command = new AttachCommand(_git, _io, _xmlIo) { FileName = _fileName, Force = true };
+
+      // Act
+      await command.ExecuteAsync(_console);
+
+      // Assert - SomeOtherProperty should survive, old HuskyRoot removed, new one added
+      _xmlDoc.Descendants("SomeOtherProperty").Should().HaveCount(1);
+      _xmlDoc.Descendants("HuskyRoot").Should().HaveCount(1);
+      _xmlIo.Received(1).Save(Arg.Any<string>(), Arg.Any<XElement>());
+   }
+
+   [Fact]
    public async Task Attach_WhenIgnoreSubmoduleIsTrue_ShouldAddSubmoduleTargetCondition()
    {
       // Arrange


### PR DESCRIPTION
# Description

After #168 added incremental build support, the MSBuild target grew from 1 user-editable path (`WorkingDirectory`) to 6 (`Inputs`, `Outputs`, `WorkingDirectory`, `Touch.Files`, `Touch.Condition`, `FileWrites.Include`). If a user's project isn't at the default `../../` depth from the repo root, they have to find and update all six. This was flagged flagged this in the review, asking if we could "define the husky working directory once and reuse it."

At the time I avoided it because I couldn't define anything _inside_ the target that worked for inputs and outputs. However, after reflecting a bit more, we can just define a property _outside_ the target and use it. The property uses `Condition="'$(HuskyRoot)' == ''"` following MSBuild best practices for `.targets` files, so users can override it from `Directory.Build.props`, their `.csproj`, etc. `dotnet husky attach` generates this automatically with the correct computed path, so automated users see no change. Manual users now update one value instead of six.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have made corresponding changes to the documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] I did test corresponding changes on **Windows**
- [X] I did test corresponding changes on **Linux**
- [ ] I did test corresponding changes on **Mac**
