### PR TITLE
Replace Inputs/Outputs with stamp existence check for incremental builds

### DIFF
--- a/docs/guide/automate.md
+++ b/docs/guide/automate.md
@@ -36,9 +36,9 @@ To manually attach husky to your project, add the below code to one of your proj
          WorkingDirectory="$(HuskyRoot)" />
    <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true"
           Condition="Exists('$(HuskyRoot).husky/_')" />
-   <ItemGroup>
-      <FileWrites Include="$(HuskyRoot).husky/_/install.stamp" />
-   </ItemGroup>
+</Target>
+<Target Name="HuskyClean" AfterTargets="Clean">
+   <Delete Files="$(HuskyRoot).husky/_/install.stamp" />
 </Target>
 ```
 
@@ -47,7 +47,7 @@ Update the `HuskyRoot` property value to match the relative path from your proje
 :::
 
 ::: tip
-The target skips when `.husky/_/install.stamp` exists, avoiding re-runs on every build. Running `dotnet clean` removes the stamp so the next build re-installs. If you update your tool versions, run `dotnet clean` to pick up the change.
+The `Husky` target skips when `.husky/_/install.stamp` exists, avoiding re-runs on every build. The `HuskyClean` target removes the stamp on `dotnet clean`, so the next build re-installs. If you update your tool versions, run `dotnet clean` to pick up the change.
 :::
 
 ::: tip

--- a/docs/guide/automate.md
+++ b/docs/guide/automate.md
@@ -29,9 +29,8 @@ To manually attach husky to your project, add the below code to one of your proj
    <!-- Update this to the relative path from your project to the repo root -->
    <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
 </PropertyGroup>
-<Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0"
-        Inputs="$(HuskyRoot).config/dotnet-tools.json"
-        Outputs="$(HuskyRoot).husky/_/install.stamp">
+<Target Name="Husky" AfterTargets="Restore"
+        Condition="'$(HUSKY)' != 0 and !Exists('$(HuskyRoot).husky/_/install.stamp')">
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
    <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High"
          WorkingDirectory="$(HuskyRoot)" />
@@ -48,7 +47,7 @@ Update the `HuskyRoot` property value to match the relative path from your proje
 :::
 
 ::: tip
-The target uses MSBuild incremental build support (`Inputs`/`Outputs`) to avoid re-running on every build. It only re-runs when `.config/dotnet-tools.json` changes (e.g. tool version update) or after `dotnet clean`. The stamp file is created inside `.husky/_/` which is already gitignored.
+The target skips when `.husky/_/install.stamp` exists, avoiding re-runs on every build. Running `dotnet clean` removes the stamp so the next build re-installs. If you update your tool versions, run `dotnet clean` to pick up the change.
 :::
 
 ::: tip

--- a/docs/guide/submodules.md
+++ b/docs/guide/submodules.md
@@ -38,9 +38,8 @@ The generated block will look something like this, If you're attaching husky man
    <!-- Update this to the relative path from your project to the repo root -->
    <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
 </PropertyGroup>
-<Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0"
-        Inputs="$(HuskyRoot).config/dotnet-tools.json"
-        Outputs="$(HuskyRoot).husky/_/install.stamp">
+<Target Name="Husky" AfterTargets="Restore"
+        Condition="'$(HUSKY)' != 0  and '$(IgnoreSubmodule)' != 0 and !Exists('$(HuskyRoot).husky/_/install.stamp')">
    <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
    <Exec Command="dotnet husky install --ignore-submodule" StandardOutputImportance="Low" StandardErrorImportance="High"
          WorkingDirectory="$(HuskyRoot)" />

--- a/docs/guide/submodules.md
+++ b/docs/guide/submodules.md
@@ -45,9 +45,9 @@ The generated block will look something like this, If you're attaching husky man
          WorkingDirectory="$(HuskyRoot)" />
    <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true"
           Condition="Exists('$(HuskyRoot).husky/_')" />
-   <ItemGroup>
-      <FileWrites Include="$(HuskyRoot).husky/_/install.stamp" />
-   </ItemGroup>
+</Target>
+<Target Name="HuskyClean" AfterTargets="Clean">
+   <Delete Files="$(HuskyRoot).husky/_/install.stamp" />
 </Target>
 ```
 

--- a/src/Husky/Cli/AttachCommand.cs
+++ b/src/Husky/Cli/AttachCommand.cs
@@ -110,13 +110,19 @@ public class AttachCommand : CommandBase
       touch.SetAttributeValue("Condition", "Exists('$(HuskyRoot).husky/_')");
       target.Add(touch);
 
-      var itemGroup = new XElement("ItemGroup");
-      var fileWrites = new XElement("FileWrites");
-      fileWrites.SetAttributeValue("Include", "$(HuskyRoot).husky/_/install.stamp");
-      itemGroup.Add(fileWrites);
-      target.Add(itemGroup);
-
       doc.Add(target);
+
+      // The stamp is written from a target that runs AfterTargets="Restore", so it is
+      // never recorded in the build's FileListAbsolute.txt and `dotnet clean` cannot
+      // remove it. Delete it explicitly after Clean so the next build re-installs
+      // (e.g. after a tool version bump).
+      var cleanTarget = new XElement("Target");
+      cleanTarget.SetAttributeValue("Name", "HuskyClean");
+      cleanTarget.SetAttributeValue("AfterTargets", "Clean");
+      var delete = new XElement("Delete");
+      delete.SetAttributeValue("Files", "$(HuskyRoot).husky/_/install.stamp");
+      cleanTarget.Add(delete);
+      doc.Add(cleanTarget);
    }
 
    private string GetInstallCommand()

--- a/src/Husky/Cli/AttachCommand.cs
+++ b/src/Husky/Cli/AttachCommand.cs
@@ -91,9 +91,7 @@ public class AttachCommand : CommandBase
       var target = new XElement("Target");
       target.SetAttributeValue("Name", "Husky");
       target.SetAttributeValue("AfterTargets", "Restore");
-      target.SetAttributeValue("Condition", condition);
-      target.SetAttributeValue("Inputs", "$(HuskyRoot).config/dotnet-tools.json");
-      target.SetAttributeValue("Outputs", "$(HuskyRoot).husky/_/install.stamp");
+      target.SetAttributeValue("Condition", condition + " and !Exists('$(HuskyRoot).husky/_/install.stamp')");
       var exec = new XElement("Exec");
       exec.SetAttributeValue("Command", "dotnet tool restore");
       exec.SetAttributeValue("StandardOutputImportance", "Low");

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -75,9 +75,9 @@
     <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
     <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(HuskyRoot)"/>
     <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('$(HuskyRoot).husky/_')" />
-    <ItemGroup>
-      <FileWrites Include="$(HuskyRoot).husky/_/install.stamp" />
-    </ItemGroup>
+  </Target>
+  <Target Name="HuskyClean" AfterTargets="Clean">
+    <Delete Files="$(HuskyRoot).husky/_/install.stamp" />
   </Target>
 
    <PropertyGroup Condition="'$(Configuration)' == 'IntegrationTest'">

--- a/src/Husky/Husky.csproj
+++ b/src/Husky/Husky.csproj
@@ -71,9 +71,7 @@
   <PropertyGroup>
     <HuskyRoot Condition="'$(HuskyRoot)' == ''">../../</HuskyRoot>
   </PropertyGroup>
-  <Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0 and '$(IsCrossTargetingBuild)' == 'true'"
-          Inputs="$(HuskyRoot).config/dotnet-tools.json"
-          Outputs="$(HuskyRoot).husky/_/install.stamp">
+  <Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0 and '$(IsCrossTargetingBuild)' == 'true' and !Exists('$(HuskyRoot).husky/_/install.stamp')">
     <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
     <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(HuskyRoot)"/>
     <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('$(HuskyRoot).husky/_')" />

--- a/tests/HuskyIntegrationTests/InstallStampTests.cs
+++ b/tests/HuskyIntegrationTests/InstallStampTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+
+namespace HuskyIntegrationTests;
+
+/// <summary>
+/// Tests for the MSBuild auto-install target's incremental behavior (PR #170):
+/// the target installs once (stamp existence check), and <c>dotnet clean</c>
+/// removes the stamp so the next build re-installs (e.g. after a tool version bump).
+/// </summary>
+public class InstallStampTests(ITestOutputHelper output)
+{
+   private const string StampPath = ".husky/_/install.stamp";
+   private static readonly string StampExists =
+      $"test -f {StampPath} && echo STAMP_EXISTS || echo STAMP_MISSING";
+   private static readonly string StampMtime =
+      $"stat -c %Y {StampPath} 2>/dev/null || echo NONE";
+
+   [Fact]
+   public async Task DotnetClean_RemovesInstallStamp_SoNextBuildReinstalls()
+   {
+      // arrange: a project with the husky MSBuild target attached
+      await using var c = await DockerHelper.StartWithInstalledHusky();
+      await c.BashAsync("dotnet husky attach TestProjectBase.csproj");
+
+      // act 1: the first build runs the install and writes the stamp.
+      await c.BashAsync(output, "dotnet build TestProjectBase.csproj");
+      var afterBuild = await c.BashAsync(output, StampExists);
+      afterBuild.Stdout.Should().Contain("STAMP_EXISTS", "the first build should install husky and create the stamp");
+
+      // act 2: dotnet clean should remove the stamp so a later build re-installs
+      await c.BashAsync(output, "dotnet clean TestProjectBase.csproj");
+      var afterClean = await c.BashAsync(output, StampExists);
+
+      // assert: the stamp is gone after clean
+      afterClean.Stdout.Should().Contain("STAMP_MISSING", "dotnet clean should remove the install stamp");
+
+      // act 3 + assert: the next build re-creates it (recovery path works end to end)
+      await c.BashAsync(output, "dotnet build TestProjectBase.csproj");
+      var afterRebuild = await c.BashAsync(output, StampExists);
+      afterRebuild.Stdout.Should().Contain("STAMP_EXISTS", "the build after clean should re-install and re-create the stamp");
+   }
+
+   [Fact]
+   public async Task SecondBuild_DoesNotReinstall_WhenStampExists()
+   {
+      // arrange: a project with the husky MSBuild target attached
+      await using var c = await DockerHelper.StartWithInstalledHusky();
+      await c.BashAsync("dotnet husky attach TestProjectBase.csproj");
+
+      // act: build twice in a row. Build the project explicitly: a solution-level
+      // restore does not run the project's AfterTargets="Restore" target.
+      await c.BashAsync(output, "dotnet build TestProjectBase.csproj");
+      var firstMtime = (await c.BashAsync(output, StampMtime)).Stdout.Trim();
+      firstMtime.Should().NotBe("NONE", "the first build should create the stamp");
+
+      await c.BashAsync(output, "dotnet build TestProjectBase.csproj");
+      var secondMtime = (await c.BashAsync(output, StampMtime)).Stdout.Trim();
+
+      // assert: the stamp was not re-touched, so the install target ran only once
+      secondMtime.Should().Be(firstMtime, "the second build should skip the install target because the stamp already exists");
+   }
+}

--- a/tests/HuskyTest/Cli/AttachCommandTests.cs
+++ b/tests/HuskyTest/Cli/AttachCommandTests.cs
@@ -76,7 +76,15 @@ public class AttachCommandTests
       touch.Attribute("AlwaysCreate")?.Value.Should().Be("true");
       touch.Attribute("Condition")?.Value.Should().Contain("Exists(");
 
-      huskyTarget.Descendants("ItemGroup").Descendants("FileWrites").Should().HaveCount(1);
+      huskyTarget.Descendants("ItemGroup").Descendants("FileWrites").Should().BeEmpty();
+
+      // A sibling HuskyClean target deletes the stamp on Clean so the next build re-installs
+      var huskyCleanTarget = _xmlDoc.Descendants("Target")
+         .FirstOrDefault(q => q.Attribute("Name")?.Value == "HuskyClean");
+      huskyCleanTarget.Should().NotBeNull();
+      huskyCleanTarget!.Attribute("AfterTargets")?.Value.Should().Be("Clean");
+      var delete = huskyCleanTarget.Descendants("Delete").Should().ContainSingle().Subject;
+      delete.Attribute("Files")?.Value.Should().Be("$(HuskyRoot).husky/_/install.stamp");
 
       _console.ReadOutputString().Trim().Should().Be("Husky dev-dependency successfully attached to this project.");
    }
@@ -110,7 +118,7 @@ public class AttachCommandTests
       await command.ExecuteAsync(_console);
 
       // Assert
-      _xmlDoc.Descendants("Target").Should().HaveCount(1);
+      _xmlDoc.Descendants("Target").Should().HaveCount(2);
       _xmlDoc.Descendants("Target")
          .SingleOrDefault(q => q.Attribute("Name")?.Value == "Husky")?.Descendants("Exec")
          .Should().NotBeNull().And.HaveCount(2);
@@ -150,7 +158,7 @@ public class AttachCommandTests
       await command.ExecuteAsync(_console);
 
       // Assert
-      _xmlDoc.Descendants("Target").Should().HaveCount(1);
+      _xmlDoc.Descendants("Target").Should().HaveCount(2);
       _xmlDoc.Descendants("Target")
          .SingleOrDefault(q => q.Attribute("Name")?.Value == "Husky")?.Descendants("Exec")
          .Should().NotBeNull().And.HaveCount(2);
@@ -173,7 +181,7 @@ public class AttachCommandTests
       await command.ExecuteAsync(_console);
 
       // Assert
-      _xmlDoc.Descendants("Target").Should().HaveCount(1);
+      _xmlDoc.Descendants("Target").Should().HaveCount(2);
 
       var targetExecElements = _xmlDoc.Descendants("Target")
          .SingleOrDefault(q => q.Attribute("Name")?.Value == "Husky")?.Descendants("Exec").ToList();
@@ -216,7 +224,9 @@ public class AttachCommandTests
              <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
              <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(HuskyRoot)" />
              <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('$(HuskyRoot).husky/_')" />
-             <ItemGroup><FileWrites Include="$(HuskyRoot).husky/_/install.stamp" /></ItemGroup>
+           </Target>
+           <Target Name="HuskyClean" AfterTargets="Clean">
+             <Delete Files="$(HuskyRoot).husky/_/install.stamp" />
            </Target>
          </Project>
          """);

--- a/tests/HuskyTest/Cli/AttachCommandTests.cs
+++ b/tests/HuskyTest/Cli/AttachCommandTests.cs
@@ -66,8 +66,9 @@ public class AttachCommandTests
          .FirstOrDefault(q => q.Attribute("Name")?.Value == "Husky");
       huskyTarget.Should().NotBeNull();
       huskyTarget!.Descendants("Exec").Should().HaveCount(2);
-      huskyTarget.Attribute("Inputs").Should().NotBeNull();
-      huskyTarget.Attribute("Outputs").Should().NotBeNull();
+      huskyTarget.Attribute("Condition")?.Value.Should().Contain("!Exists(");
+      huskyTarget.Attribute("Inputs").Should().BeNull();
+      huskyTarget.Attribute("Outputs").Should().BeNull();
 
       // Verify Touch is conditioned on directory existence
       huskyTarget.Descendants("Touch").Should().HaveCount(1);
@@ -211,8 +212,7 @@ public class AttachCommandTests
          <Project Sdk="Microsoft.NET.Sdk">
            <PropertyGroup><TargetFramework>netcoreapp2.1</TargetFramework></PropertyGroup>
            <PropertyGroup><HuskyRoot Condition="'$(HuskyRoot)' == ''">{{expectedHuskyRoot}}</HuskyRoot></PropertyGroup>
-           <Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0"
-                   Inputs="$(HuskyRoot).config/dotnet-tools.json" Outputs="$(HuskyRoot).husky/_/install.stamp">
+           <Target Name="Husky" AfterTargets="Restore" Condition="'$(HUSKY)' != 0 and !Exists('$(HuskyRoot).husky/_/install.stamp')">
              <Exec Command="dotnet tool restore" StandardOutputImportance="Low" StandardErrorImportance="High" />
              <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High" WorkingDirectory="$(HuskyRoot)" />
              <Touch Files="$(HuskyRoot).husky/_/install.stamp" AlwaysCreate="true" Condition="Exists('$(HuskyRoot).husky/_')" />

--- a/tests/HuskyTest/HuskyTest.csproj
+++ b/tests/HuskyTest/HuskyTest.csproj
@@ -26,4 +26,10 @@
       <ProjectReference Include="..\..\src\Husky\Husky.csproj" />
    </ItemGroup>
 
+   <ItemGroup>
+      <Content Include="xunit.runner.json">
+         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+   </ItemGroup>
+
 </Project>

--- a/tests/HuskyTest/xunit.runner.json
+++ b/tests/HuskyTest/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+   "parallelizeTestCollections": false
+}


### PR DESCRIPTION
# Description

Follow-up to #169 (should be merged first or taken together).

.NET SDK 10.0.102 intentionally changed where `dotnet new tool-manifest` places the manifest file, from `.config/dotnet-tools.json` to the current directory ([dotnet/sdk#49296](https://github.com/dotnet/sdk/issues/49296)). The SDK's manifest
discovery walks up the directory tree checking both `dotnet-tools.json` and `.config/dotnet-tools.json` at each level, so manifests can now live anywhere along the path to root.

The MSBuild target's `Inputs` attribute had a hardcoded path to `.config/dotnet-tools.json`. On repos created with SDK 10.0.102+, this file doesn't exist, so MSBuild can't do the timestamp comparison, and the target re-runs every build, defeating the incremental optimization.

Rather than adding manifest discovery logic to MSBuild XML, this replaces the `Inputs`/`Outputs` mechanism with a simpler `!Exists(stamp)` condition. The target runs once (creating the stamp), then skips on all subsequent builds. `dotnet clean`
removes the stamp (via `FileWrites`), so the next build re-installs. If you update tool versions in the manifest, run `dotnet clean` or `dotnet tool install` to pick up the change.

Alternatively, we _could_ create another ItemGroup or Target that searches for the dotnet-tools.json file before calling our Husky target. If we want the most deterministic build possible, I'm happy to make that change instead. However, in that case I'd suggest dropping the manual install instructions and pushing everyone more forcefully towards the attach command as part of the same change.

Depends on #169.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have made corresponding changes to the documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] I did test corresponding changes on **Windows**
- [X] I did test corresponding changes on **Linux**
- [ ] I did test corresponding changes on **Mac**
